### PR TITLE
【Hotfix】記事編集でコンテンツを変更せずに編集確定した場合、 コンテンツが空で上書きされる問題を修正

### DIFF
--- a/source/frontend/packages/blog-admin/src/features/blogPost/editor/blogPostEditor/BlogPostEditor.tsx
+++ b/source/frontend/packages/blog-admin/src/features/blogPost/editor/blogPostEditor/BlogPostEditor.tsx
@@ -7,6 +7,7 @@ import { MarkdownShortcutPlugin } from '@lexical/react/LexicalMarkdownShortcutPl
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin';
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import { $getRoot, type EditorState } from 'lexical';
+import { useEffect } from 'react';
 import type { BlogPostContent } from 'shared-lib/src/api';
 import { useBlogPostContentsContext } from './BlogPostContentsProvider';
 import styles from './blogPostEditor.module.scss';
@@ -26,6 +27,14 @@ type BlogPostEditorProps = {
 
 function BlogPostEditor({ initialContents }: BlogPostEditorProps) {
   const { setBlogPostContents } = useBlogPostContentsContext();
+
+  // 初回レンダリング時に初期コンテンツを設定
+  useEffect(() => {
+    if (initialContents) {
+      setBlogPostContents(initialContents);
+    }
+  }, [initialContents, setBlogPostContents]);
+
   const onChange = (editor: EditorState) => {
     editor.read(() => {
       const root = $getRoot();


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: 子のプルリクエストをレビューしてコメントする際には日本語でお願いします。 -->
<!-- GitHub Copilot コードレビューへの指示: 変数・関数・クラス等の命名について、より良いものがあればレビューコメントとして残してください -->
